### PR TITLE
Security issue - Missing Cluster Public Key in fargate template

### DIFF
--- a/aws/fargate.yml
+++ b/aws/fargate.yml
@@ -269,6 +269,8 @@ Resources:
               Value: notrequired
             - Name: BUGSNAG_API_KEY
               Value: ""
+            - Name: CLUSTER_PUBLIC_KEY
+              Value: !Ref ClusterPublicKey
 
           Ulimits:
             - Name: nofile


### PR DESCRIPTION
**Problem**

The fargate cloud formation template has a problem: it is not passing the parameter CLUSTER_PUBLIC_KEY to the docker image environment. As a result, the deployed cluster is not secured: anyone can add, remove and deploy projects into it.

**Solution**
This problem is fixed by adding these two lines:
```yml
- Name: CLUSTER_PUBLIC_KEY
  Value: !Ref ClusterPublicKey
```